### PR TITLE
feat: Update READMEs and add GitHub Pages landing page

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-JsonSchema
-==========
+# Repository for Schemas, Taxonomies, and UUIDs
+
+This repository serves as a central registry for various schemas, taxonomies, and UUID definitions. The goal is to provide both machine-readable and human-readable versions of these resources.
+
+## Directory Structure
+
+- **/schemas**: Contains machine-readable schema definitions (e.g., JSON Schema, XML Schema).
+- **/taxonomies**: Contains taxonomy definitions (e.g., JSON-LD, RDF XML, plain text).
+- **/uuids**: Contains definitions and information related to UUIDs used within the project or organization.
+- **/docs**: Contains human-readable documentation, published as a GitHub Pages site for easy browser access.
+- **/examples**: Contains example files demonstrating the usage or implementation of the schemas and taxonomies.
+
+Feel free to explore the directories and contribute by following the guidelines (to be defined).

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,7 @@
+# Documentation (GitHub Pages)
+
+This directory contains the source files for the project's GitHub Pages site.
+
+The main landing page is `index.html`.
+
+Any static assets like CSS, JavaScript, or images for the documentation site should also be placed here or in subdirectories.

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Project Registry</title>
+    <style>
+        body { font-family: sans-serif; margin: 0; background-color: #f4f4f4; color: #333; }
+        header { background-color: #333; color: #fff; padding: 1em 0; text-align: center; }
+        nav { background-color: #444; padding: 0.5em; text-align: center; }
+        nav a { color: #fff; margin: 0 1em; text-decoration: none; }
+        nav a:hover { text-decoration: underline; }
+        .container { max-width: 960px; margin: 2em auto; padding: 1em; background-color: #fff; box-shadow: 0 0 10px rgba(0,0,0,0.1); }
+        h1, h2 { color: #333; }
+        section { margin-bottom: 1.5em; }
+        footer { text-align: center; padding: 1em 0; background-color: #333; color: #fff; margin-top: 2em; }
+    </style>
+</head>
+<body>
+    <header>
+        <h1>Welcome to the Project Registry</h1>
+    </header>
+    <nav>
+        <a href="#schemas">Schemas</a>
+        <a href="#taxonomies">Taxonomies</a>
+        <a href="#uuids">UUIDs</a>
+        <a href="#examples">Examples</a>
+    </nav>
+    <div class="container">
+        <section id="intro">
+            <h2>About This Registry</h2>
+            <p>This site provides access to various schemas, taxonomies, and UUID definitions used within our projects. Our goal is to maintain a clear, organized, and accessible collection of these resources.</p>
+        </section>
+        <section id="schemas">
+            <h2>Schemas</h2>
+            <p>Machine-readable definitions for data structures and formats. You can find JSON Schemas, XML Schemas, and other formal definitions here.</p>
+            <p><a href="../schemas/">Browse Schemas &rarr;</a></p>
+        </section>
+        <section id="taxonomies">
+            <h2>Taxonomies</h2>
+            <p>Organized classifications and vocabularies. These may include ontologies in formats like JSON-LD or RDF XML, as well as simpler controlled vocabularies.</p>
+            <p><a href="../taxonomies/">Browse Taxonomies &rarr;</a></p>
+        </section>
+        <section id="uuids">
+            <h2>UUIDs</h2>
+            <p>Definitions and information related to Universally Unique Identifiers (UUIDs) used for identifying resources or entities within the project ecosystem.</p>
+            <p><a href="../uuids/">Browse UUIDs &rarr;</a></p>
+        </section>
+        <section id="examples">
+            <h2>Examples</h2>
+            <p>Illustrative examples demonstrating how to use the defined schemas and taxonomies.</p>
+            <p><a href="../examples/">View Examples &rarr;</a></p>
+        </section>
+    </div>
+    <footer>
+        <p>&copy; 2023 Your Project/Organization Name</p>
+    </footer>
+</body>
+</html>

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,0 +1,5 @@
+# Examples
+
+This directory contains example files that demonstrate the usage or implementation of the schemas, taxonomies, and other definitions found in this repository.
+
+These examples can help users understand how to correctly apply the defined structures and vocabularies.

--- a/uuids/README.md
+++ b/uuids/README.md
@@ -1,0 +1,3 @@
+# UUIDs
+
+This directory contains definitions and information related to Universally Unique Identifiers (UUIDs) used within the project or organization.


### PR DESCRIPTION
This commit implements the following changes:
- Updated the main README.md with a new title, a description of the repository's purpose, and an overview of the directory structure.
- Created an initial `index.html` landing page in the `docs/` directory for the GitHub Pages site. This page provides a brief introduction and links to the different sections of the repository.
- Added `README.md` files to the `uuids`, `docs`, and `examples` directories to explain their respective purposes. These were pending from the initial structure setup.

The repository now has a more comprehensive set of introductory documentation both at the root level and for the GitHub Pages site.